### PR TITLE
Table JS Fix

### DIFF
--- a/js/index.js
+++ b/js/index.js
@@ -6,6 +6,10 @@
 jQuery(document).ready( function($) {
 
 	// Unforunently, there's no hooks or filters so we need to "hack" this `tr` row into the table.
+	const table = $('.form-table').first().find('tr:nth-child(1)');
+	$('#psdn--tr-row').insertAfter(table);
+
+	// Unforunently, there's no hooks or filters so we need to "hack" this `tr` row into the table.
 	$('#psdn--tr-row').insertAfter('table.form-table tr:nth-child(1)');
 
 	// Wrapping the to-be-moved `tr` in a table keeps the browsers DOM happy, lets remove it now.


### PR DESCRIPTION
👋  There are instances where a user can hook into `network_site_new_form` and create other `<table class"form-table">` elements. The following changes makes it so it just grabs the first instance of `.form-table`.